### PR TITLE
fix - install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,10 +55,10 @@ if [ ! -f "$HOME/.zshrc" ]; then
 fi
 
 if [ -f "$HOME/.zshrc" ]; then
-	echo "export PATH=\"$BINARY_PATH:\$PATH\"" >> "$HOME/.zshrc"
+	echo "\nexport PATH=\"$BINARY_PATH:\$PATH\"" >> "$HOME/.zshrc"
 fi
 if [ -f "$HOME/.bashrc" ]; then
-	echo "export PATH=\"$BINARY_PATH:\$PATH\"" >> "$HOME/.bashrc"
+	echo "\nexport PATH=\"$BINARY_PATH:\$PATH\"" >> "$HOME/.bashrc"
 fi
 
 "${BINARY_PATH}/${FILE_BASENAME}" welcome -i -o="$OS" -m="curl" -v="$VERSION" -a="$ARCH"


### PR DESCRIPTION
## Why
The alias added to the ZSHRC or BASHRC wasn't been added on a new line

## What is changing
add the alias path on a new line, introducing a line break on the command

## How to test
run install script and open the zshrc or bashrc file to verify