### PR TITLE
fix - token bug, srt time format

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,7 +30,7 @@ var configCmd = &cobra.Command{
 
 		checkToken := U.CheckIfTokenValid()
 		if !checkToken {
-			fmt.Println("Your token appears to be invalid. Try again, and if the problem persists, contact support at support@assemblyai.com")
+			fmt.Println(U.INVALID_TOKEN)
 			return
 		}
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -43,6 +43,16 @@ var getCmd = &cobra.Command{
 			return
 		}
 
+		checkToken := U.CheckIfTokenValid()
+		if !checkToken {
+			printErrorProps := S.PrintErrorProps{
+				Error:   errors.New("Invalid token"),
+				Message: "Your token appears to be invalid. Try again, and if the problem persists, contact support at support@assemblyai.com",
+			}
+			U.PrintError(printErrorProps)
+			return
+		}
+
 		U.PollTranscription(id, flags)
 	},
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -47,7 +47,7 @@ var getCmd = &cobra.Command{
 		if !checkToken {
 			printErrorProps := S.PrintErrorProps{
 				Error:   errors.New("Invalid token"),
-				Message: "Your token appears to be invalid. Try again, and if the problem persists, contact support at support@assemblyai.com",
+				Message: U.INVALID_TOKEN,
 			}
 			U.PrintError(printErrorProps)
 			return

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ func TestValidate(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Please start by running \033[1m\033[34massemblyai config [token]\033[0m\n" {
+	if string(out) != "\nPlease start by running \033[1m\033[34massemblyai config [token]\033[0m\n" {
 		t.Errorf("Expected Please start by running \033[1m\033[34massemblyai config [token]\033[0m, got %s.", string(out))
 	}
 }
@@ -60,7 +60,7 @@ func TestTranscribeInvalidFlags(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "requires at least 1 arg(s), only received 0\n" {
+	if string(out) != "\nrequires at least 1 arg(s), only received 0\n" {
 		t.Errorf("Expected requires at least 1 arg(s), only received 0, got %s.", string(out))
 	}
 }
@@ -70,7 +70,7 @@ func TestTranscribeBadYoutube(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Could not find YouTube ID in URL\n" {
+	if string(out) != "\nCould not find YouTube ID in URL\n" {
 		t.Errorf("Expected Could not find YouTube ID in URL, got %s.", string(out))
 	}
 }
@@ -80,7 +80,7 @@ func TestTranscribeBadFile(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Error opening file\n" {
+	if string(out) != "\nError opening file\n" {
 		t.Errorf("Expected Error opening file, got %s.", string(out))
 	}
 }
@@ -165,7 +165,7 @@ func TestTranscribeRestrictions(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Speaker labels are not supported for dual channel audio\n" {
+	if string(out) != "\nSpeaker labels are not supported for dual channel audio\n" {
 		t.Errorf("Expected Speaker labels are not supported for dual channel audio, got %s.", string(out))
 	}
 
@@ -185,7 +185,7 @@ func TestTranscribeRestrictions(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Auto chapters are not supported for summarization\n" {
+	if string(out) != "\nAuto chapters are not supported for summarization\n" {
 		t.Errorf("Expected Auto chapters are not supported for summarization, got %s.", string(out))
 	}
 
@@ -205,7 +205,7 @@ func TestTranscribeRestrictions(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Please provide either language detection or language code, not both.\n" {
+	if string(out) != "\nPlease provide either language detection or language code, not both.\n" {
 		t.Errorf("Expected Please provide either language detection or language code, not both., got %s.", string(out))
 	}
 
@@ -225,7 +225,7 @@ func TestTranscribeRestrictions(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Speaker labels are not supported for languages other than English.\n" {
+	if string(out) != "\nSpeaker labels are not supported for languages other than English.\n" {
 		t.Errorf("Expected Speaker labels are not supported for languages other than English., got %s.", string(out))
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	S "github.com/AssemblyAI/assemblyai-cli/schemas"
 	"github.com/AssemblyAI/assemblyai-cli/utils"
+	U "github.com/AssemblyAI/assemblyai-cli/utils"
 )
 
 func TestVersion(t *testing.T) {
@@ -39,7 +40,7 @@ func TestAuthBad(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "Your token appears to be invalid. Try again, and if the problem persists, contact support at support@assemblyai.com\n" {
+	if string(out) != U.INVALID_TOKEN+"\n" {
 		t.Errorf("Expected Something just went wrong. Please try again., got %s.", string(out))
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ func TestValidate(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	if string(out) != "\nPlease start by running \033[1m\033[34massemblyai config [token]\033[0m\n" {
+	if string(out) != "Please start by running \033[1m\033[34massemblyai config [token]\033[0m\n" {
 		t.Errorf("Expected Please start by running \033[1m\033[34massemblyai config [token]\033[0m, got %s.", string(out))
 	}
 }

--- a/schemas/types.go
+++ b/schemas/types.go
@@ -65,7 +65,7 @@ type TranscriptResponse struct {
 	SpeedBoost               *bool                      `json:"speed_boost,omitempty"`
 	Status                   *string                    `json:"status,omitempty"`
 	Summarization            *bool                      `json:"summarization,omitempty"`
-	Summary                  *string                    `json:"summary,omitempty"`
+	Summary                  *interface{}               `json:"summary,omitempty"`
 	SummaryType              *string                    `json:"summary_type,omitempty"`
 	Text                     *string                    `json:"text,omitempty"`
 	Throttled                interface{}                `json:"throttled"`
@@ -402,4 +402,12 @@ var ValidFileTypes = []string{
 	"m4p",
 	"m4v",
 	"mxf",
+}
+
+type SummaryObject struct {
+	Summary  string `json:"summary"`
+	Headline string `json:"headline"`
+	Gist     string `json:"gist"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -32,6 +32,7 @@ func CheckIfTokenValid() bool {
 			Message: "Something went wrong. Please try again.",
 		}
 		PrintError(printErrorProps)
+		return false
 	}
 	if result.Error != nil {
 		return false

--- a/utils/messages.go
+++ b/utils/messages.go
@@ -1,0 +1,3 @@
+package utils
+
+var INVALID_TOKEN = "Your token is invalid. Try running assemblyai config [new_token], and if the problem persists, contact support at support@assemblyai.com"

--- a/utils/transcribe.go
+++ b/utils/transcribe.go
@@ -34,6 +34,16 @@ func Transcribe(params S.TranscribeParams, flags S.TranscribeFlags) {
 		return
 	}
 
+	checkToken := CheckIfTokenValid()
+	if !checkToken {
+		printErrorProps := S.PrintErrorProps{
+			Error:   errors.New("Invalid token"),
+			Message: "Your token appears to be invalid. Try again, and if the problem persists, contact support at support@assemblyai.com",
+		}
+		PrintError(printErrorProps)
+		return
+	}
+
 	if isUrl(params.AudioURL) {
 		if isYoutubeLink(params.AudioURL) {
 			if isYoutubeShortLink(params.AudioURL) {
@@ -391,7 +401,7 @@ func dualChannelPrintFormatted(utterances *[]S.SentimentAnalysisResult) {
 	table.Wrap = true
 	table.MaxColWidth = uint(width - 21)
 	for _, utterance := range *utterances {
-		start := TransformMsToTimestamp(*utterance.Start)
+		start := TransformMsToTimestamp(*utterance.Start, false)
 		speaker := fmt.Sprintf("(Channel %s)", utterance.Channel)
 
 		sentences := SplitSentences(utterance.Text, false)
@@ -533,8 +543,8 @@ func chaptersPrintFormatted(chapters *[]S.Chapter) {
 	table.MaxColWidth = uint(width - 19)
 	table.Separator = " |\t"
 	for _, chapter := range *chapters {
-		start := TransformMsToTimestamp(*chapter.Start)
-		end := TransformMsToTimestamp(*chapter.End)
+		start := TransformMsToTimestamp(*chapter.Start, false)
+		end := TransformMsToTimestamp(*chapter.End, false)
 		table.AddRow("| timestamp", fmt.Sprintf("%s-%s", start, end))
 		table.AddRow("| Gist", chapter.Gist)
 		table.AddRow("| Headline", chapter.Headline)

--- a/utils/transcribe.go
+++ b/utils/transcribe.go
@@ -38,7 +38,7 @@ func Transcribe(params S.TranscribeParams, flags S.TranscribeFlags) {
 	if !checkToken {
 		printErrorProps := S.PrintErrorProps{
 			Error:   errors.New("Invalid token"),
-			Message: "Your token appears to be invalid. Try again, and if the problem persists, contact support at support@assemblyai.com",
+			Message: INVALID_TOKEN,
 		}
 		PrintError(printErrorProps)
 		return

--- a/utils/transcribe.go
+++ b/utils/transcribe.go
@@ -250,7 +250,6 @@ func PollTranscription(id string, flags S.TranscribeFlags) {
 		}
 		var transcript S.TranscriptResponse
 		if err := json.Unmarshal(response, &transcript); err != nil {
-			fmt.Println(err)
 			printErrorProps := S.PrintErrorProps{
 				Error:   err,
 				Message: "Something went wrong. Please try again.",
@@ -593,12 +592,13 @@ func summaryPrintFormatted(summary interface{}) {
 		fmt.Println("Could not retrieve summary")
 		return
 	}
-	// check if summary is a string
 	table := uitable.New()
 	table.Wrap = true
 	table.MaxColWidth = uint(width - 20)
 	table.Separator = " |\t"
 
+	// summary could be either a string or Array<Record<string, string | number>>
+	// check if summary is a string
 	if _, ok := (summary).(string); ok {
 		table.AddRow(summary)
 	} else {
@@ -610,7 +610,6 @@ func summaryPrintFormatted(summary interface{}) {
 			table.AddRow("| Summary", row["summary"].(string))
 			table.AddRow("", "")
 		}
-
 	}
 
 	fmt.Println(table)


### PR DESCRIPTION
## Why

1. CLI does not show a proper error when the token gets refreshed
2. Improve `.srt` timestamps
3. Fix summary display when type is not string

## What is changing

1. Check for a valid token before executing any command
2. Change .srt timestamps format to `hh:mm:ss,sss`
3. Support for summary of type `map[string]interface{}` 

## How to test

1. `--srt` flag on any command
2. refresh token and rerun a command