### PR TITLE
fix - move language check responsability from CLI to API

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -170,18 +170,6 @@ var transcribeCmd = &cobra.Command{
 			U.PrintError(printErrorProps)
 			return
 		}
-		if (languageCode != "" || languageDetection) && params.SpeakerLabels {
-			if cmd.Flags().Lookup("speaker_labels").Changed {
-				printErrorProps := S.PrintErrorProps{
-					Error:   errors.New("Speaker labels are not supported for languages other than English"),
-					Message: "Speaker labels are not supported for languages other than English.",
-				}
-				U.PrintError(printErrorProps)
-				return
-			} else {
-				params.SpeakerLabels = false
-			}
-		}
 		if languageDetection && languageCode == "" {
 			params.LanguageDetection = true
 		}


### PR DESCRIPTION
## Why
In order to keep up with AssemblyAI's rapid growth on features, it's been decided to move the checks from language and speaker labels away from the CLI into the API

## What is changing
Move the language check responsibility from CLI to the API

## How to test
`assemblyai transcribe [file] --language_code=en_uk -l=true`