### PR TITLE
Include commad to load shell configuration after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,25 @@ brew install assemblyai
 If you don't have Homebrew installed, or are running Linux:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/AssemblyAI/assemblyai-cli/main/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/AssemblyAI/assemblyai-cli/main/install.sh)" &&
+
+case "$SHELL" in
+    *bash*)
+        if [ -f "$HOME/.bashrc" ]; then
+            # if the shell contains "bash" and .bashrc is present
+            source $HOME/.bashrc
+        fi
+        ;;
+    *zsh*)
+        if [ -f "$HOME/.zshrc" ]; then
+            # if the shell contains "zsh" and .zshrc is present
+            source $HOME/.zshrc
+        fi
+        ;;
+    *)
+        echo "Unknown shell or required configuration file not found."
+        ;;
+esac
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ brew install assemblyai
 If you don't have Homebrew installed, or are running Linux:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/AssemblyAI/assemblyai-cli/main/install.sh)" &&
-
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/AssemblyAI/assemblyai-cli/main/install.sh)"
+```
+Load the shell configuration file
+```bash
 case "$SHELL" in
     *bash*)
         if [ -f "$HOME/.bashrc" ]; then


### PR DESCRIPTION
## Why
The PATH environment variable does not get updated after running the `install.sh` script, 
As a result the user would have to manually source the shell configuration file in order to update the environment variables or open a new terminal session.
![Screenshot_20230629_172613](https://github.com/AssemblyAI/assemblyai-cli/assets/44388122/32273e43-ef17-4108-876b-3ab905b04382)


Even though the below conditional statement to source the configuration file is present in install.sh at the end of file
```bash
if [ -f "$HOME/.bashrc" ]; then
	source "$HOME/.bashrc"
fi
if [ -f "$HOME/.zshrc" ]; then
	zsh
	source "$HOME/.zshrc"
fi
```
But it won't work (in some cases it will) because shell scripts by default run in a non interactive shell and source command only works when the shell is in interactive mode. Which means the environment variables declared or updated while running the `install.sh` file won't be reflected in the user's shell.

## What is changing
A case statement has been added below the previous command which was used to run `install.sh` so that the configuration can be sourced in the interactive shell and the environment variables are updated in the same shell instance. 

```bash
case "$SHELL" in
    *bash*)
        if [ -f "$HOME/.bashrc" ]; then
            # if the shell contains "bash" and .bashrc is present
            source $HOME/.bashrc
        fi
        ;;
    *zsh*)
        if [ -f "$HOME/.zshrc" ]; then
            # if the shell contains "zsh" and .zshrc is present
            source $HOME/.zshrc
        fi
        ;;
    *)
        echo "Unknown shell or required configuration file not found."
        ;;
esac
```

### Why did I use this approach to check shell type?
You might notice I used `"$SHELL" in  *bash*` approach which basically is checking a sub string instead of explicitly doing `$SHELL=="/bin/bash"`
This approach have some added advantages to it instead of explicit check of shell path'
- It would work even if the user shell is  `/usr/bin/bash` or `/usr/bin/zsh`
- It would work if the user has set it's customized the shell path and not using the traditional `/bin/bash` or `/usr/bin/bash`

## How to test
To test you will first need to uninstall the existing install (if present) using 
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/AssemblyAI/assemblyai-cli/main/uninstall.sh)"` and load the latest shell configuration using the above command we used before.

Verify that the `assemblyai` is not within the `PATH` entering  it on terminal

Now Install the script again using `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/AssemblyAI/assemblyai-cli/main/install.sh)"` and run the command for loading the shell configuration we used before.

As you can see below it updated the environment variable and now the user can access the `assemblyai`
![image](https://github.com/AssemblyAI/assemblyai-cli/assets/44388122/08a8d5e5-61cc-4b24-863c-51213af30a00)
