### PR TITLE
Uses zsh only if zsh is installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,11 +50,11 @@ if [ ! -f "$HOME/.bashrc" ]; then
 	touch "$HOME/.bashrc"
 fi
 
-if [ ! -f "$HOME/.zshrc" ]; then
+if [ -x "$(command -v zsh)" ] && [ ! -f "$HOME/.zshrc" ]; then
 	touch "$HOME/.zshrc"
 fi
 
-if [ -f "$HOME/.zshrc" ]; then
+if [ -x "$(command -v zsh)" ]; then
 	echo "" >> "$HOME/.zshrc"
 	echo "export PATH=\"$BINARY_PATH:\$PATH\"" >> "$HOME/.zshrc"
 fi
@@ -68,7 +68,7 @@ fi
 if [ -f "$HOME/.bashrc" ]; then
 	source "$HOME/.bashrc"
 fi
-if [ -f "$HOME/.zshrc" ]; then
+if [ -x "$(command -v zsh)" ]; then
 	zsh
 	source "$HOME/.zshrc"
 fi


### PR DESCRIPTION
Currently, the install script creates a .zshrc file, then uses the presence of that file as the indication that the system uses zsh. Instead, test that zsh is installed before taking steps to use zsh.

## Why
The install script is broken if zsh is not installed.

## What is changing
Check for zsh before configuring zsh in the install script.

## How to test
1. Run install.sh in master on a machine that doesn't have zsh installed. Install should fail with `/bin/bash: line 72: zsh: command not found`
2. Run the updated install.sh on a machine that doesn't have zsh installed. Install should succeed and the running shell should remain in place.
3. Install zsh and run the updated install.sh. Install should succeed and the running shell should switch to zsh.