### PR TITLE
disable speaker labels by default

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -264,7 +264,7 @@ func init() {
 	transcribeCmd.PersistentFlags().BoolP("punctuate", "u", true, "Enable automatic punctuation.")
 	transcribeCmd.PersistentFlags().BoolP("redact_pii", "r", false, "Remove personally identifiable information from the transcription.")
 	transcribeCmd.PersistentFlags().BoolP("sentiment_analysis", "x", false, "Detect the sentiment of each sentence of speech spoken in the file.")
-	transcribeCmd.PersistentFlags().BoolP("speaker_labels", "l", true, "Automatically detect the number of speakers in your audio file, and each word in the transcription text can be associated with its speaker.")
+	transcribeCmd.PersistentFlags().BoolP("speaker_labels", "l", false, "Automatically detect the number of speakers in your audio file, and each word in the transcription text can be associated with its speaker.")
 	transcribeCmd.PersistentFlags().BoolP("srt", "", false, "Generate an SRT file for the audio file transcribed.")
 	transcribeCmd.PersistentFlags().BoolP("summarization", "m", false, "Generate a single abstractive summary of the entire audio.")
 	transcribeCmd.PersistentFlags().BoolP("topic_detection", "t", false, "Label the topics that are spoken in the file.")


### PR DESCRIPTION
## Why
Please include the tickets/requirements that are being addressed

Using the CLI with multi-lang doesn't work because speaker labels are enabled by default. We also don't have clear documentation for disabling speaker labels and hence my proposed change will disable speaker labels by default.

## What is changing
Please describe what is being changed
Resetting Speaker Labels to be false by default.

## How to test
Please comment the steps required to reproduce the changes
Transcribe a file in another language with the CLI. For e.g.:
"assemblyai transcribe "https://www.youtube.com/watch?v=TJxDnHVX7mE" -g "es"
Expected behaviour: file is transcribed in Spanish
Current behaviour: error- speaker labels are not supported in Spanish