### PR TITLE
fix - bump go version on release gh workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.BUILD_TOKEN }}
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.BUILD_TOKEN }}
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version: '1.21'
           check-latest: true
           
       - run: go mod vendor


### PR DESCRIPTION
## Why
Actions failing due to go version

## What is changing
gh workflows file bumping go version

## How to test
running gh actions