### PR TITLE
Fix Broken Link to App

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ New-Alias -Name assemblyai -Value $Env:Programfiles/AssemblyAI/assemblyai.exe
 
 ## Getting started
 
-Get started by configuring the CLI with your AssemblyAI token. If you don't yet have an account, create one [here](https://app.assemblyai.com/).
+Get started by configuring the CLI with your AssemblyAI token. If you don't yet have an account, create one [here](https://www.assemblyai.com/app).
 
 ```bash
 assemblyai config [token]


### PR DESCRIPTION
## Why

The `Getting started` section begins with a link to create an account at [app.assemblyai.com](https://app.assemblyai.com). This URL throws an SSL error indicating link migration.

- Based on what I see in my account's dashboard, the correct URL appears to be [assemblyai.com/app](https://www.assemblyai.com/app).
- Alternatively, since you're referencing how to create an account, you could link to [assemblyai.com/dashboard/signup](https://www.assemblyai.com/dashboard/signup) since this is the URL `/app` redirects new users to.

## What is Changing

A link in the README markdown is changing from [app.assemblyai.com](https://app.assemblyai.com) to [assemblyai.com/app](https://www.assemblyai.com/app)

## How to test

Cross your fingers and click the link.