### PR TITLE
feat(transcribe): add --speech_model flag

### DIFF
--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -129,6 +129,9 @@ var transcribeCmd = &cobra.Command{
 				}
 				params.SummaryModel = summaryModel
 			}
+
+			speechModel, _ := cmd.Flags().GetString("speech_model")
+			params.SpeechModel = &speechModel
 		}
 
 		if params.RedactPii {
@@ -278,6 +281,7 @@ func init() {
 	transcribeCmd.PersistentFlags().StringP("webhook_url", "w", "", "Receive a webhook once your transcript is complete.")
 	transcribeCmd.PersistentFlags().StringP("word_boost", "k", "", "The value of this flag MUST be used surrounded by quotes. Any term included will have its likelihood of being transcribed boosted.")
 	transcribeCmd.PersistentFlags().StringP("summary_model", "q", "informative", "The model used to generate the summary.")
+	transcribeCmd.PersistentFlags().StringP("speech_model", "", "", "The speech model to use for the transcription. Allowed values: see https://www.assemblyai.com/docs/api-reference/transcripts/submit#request.body.speech_model")
 
 	transcribeCmd.Flags().Bool("test", false, "Flag for test executing purpose")
 	transcribeCmd.Flags().MarkHidden("test")

--- a/main_test.go
+++ b/main_test.go
@@ -103,6 +103,7 @@ func TestTranscribeWithFlags(t *testing.T) {
 		"--speaker_labels",
 		"--summarization",
 		"--topic_detection",
+		"--speech_model=nano",
 		"-p=false",
 		"-j",
 		"--test",
@@ -146,6 +147,9 @@ func TestTranscribeWithFlags(t *testing.T) {
 	}
 	if *result.IabCategories != true {
 		t.Errorf("Expected IAB Categories(Topic detection) true, got false.")
+	}
+	if result.SpeechModel == nil || *result.SpeechModel != "nano" {
+		t.Errorf("Expected speech_model to be 'nano', got '%v'.", result.SpeechModel)
 	}
 }
 

--- a/schemas/types.go
+++ b/schemas/types.go
@@ -62,6 +62,7 @@ type TranscriptResponse struct {
 	SentimentAnalysis        *bool                      `json:"sentiment_analysis,omitempty"`
 	SentimentAnalysisResults *[]SentimentAnalysisResult `json:"sentiment_analysis_results,omitempty"`
 	SpeakerLabels            bool                       `json:"speaker_labels,omitempty"`
+	SpeechModel              *string                    `json:"speech_model,omitempty"`
 	SpeedBoost               *bool                      `json:"speed_boost,omitempty"`
 	Status                   *string                    `json:"status,omitempty"`
 	Summarization            *bool                      `json:"summarization,omitempty"`
@@ -208,6 +209,7 @@ type TranscribeParams struct {
 	WebhookAuthHeaderValue string           `json:"webhook_auth_header_value,omitempty"`
 	WebhookURL             string           `json:"webhook_url,omitempty"`
 	WordBoost              []string         `json:"word_boost,omitempty"`
+	SpeechModel            *string          `json:"speech_model,omitempty"`
 }
 
 type CustomSpelling struct {


### PR DESCRIPTION
## Why
There was previously no CLI arg to customize the speech model to be used in the transcription API, so I added it.

## What is changing
It is now possible to do `assemblyai transcribe --speech_model=universal ...` (where universal is one of the possible speech models supported in the API, see https://www.assemblyai.com/docs/api-reference/transcripts/submit#request.body.speech_model)

## How to test
Just run the automated tests, one test was modified to supply speech_model=nano to the API and check that the API response actually contains speech_model: "nano"