### PR TITLE
Mark AssemblyAI CLI as retired in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AssemblyAI CLI
+# AssemblyAI CLI (Retired)
 
 > [!IMPORTANT]
 > As of August 2026, this repo for the AssemblyAI CLI **has been discontinued** and will no longer be maintained.


### PR DESCRIPTION
Updated README to indicate that the AssemblyAI CLI has been discontinued.

## Why
Please include the tickets/requirements that are being addressed

## What is changing
Please describe what is being changed

## How to test
Please comment the steps required to reproduce the changes